### PR TITLE
prevent error output when preferred_erase_size is missing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,9 @@ function waitdev {
 }
 
 function formatimage {
-  esize_mb=$(cat /sys/block/${device/"/dev/"/""}/device/preferred_erase_size) 
+  if [ -f /sys/block/${device/"/dev/"/""}/device/preferred_erase_size ]; then
+    esize_mb=$(cat /sys/block/${device/"/dev/"/""}/device/preferred_erase_size)
+  fi
   [ -z "$esize_mb" ] && esize_mb=$SD_ERASE_SIZE_MB || esize_mb=$(( $esize_mb /1024 /1024 ))
   echo "Erase size = $esize_mb MB"
   minimalbootstart_kb=$(( $SPL_START_KB + ($MINIMAL_SIZE_UBOOT_MB * 1024) ))


### PR DESCRIPTION
`cat` will output an error when the file is missing