### PR TITLE
Remove 'xf86-video-armsoc-rockchip'

### DIFF
--- a/rootfs/usr/local/bin/rockchip-postinstall
+++ b/rootfs/usr/local/bin/rockchip-postinstall
@@ -17,7 +17,7 @@ if ! pacman -Qg xorg  &>/dev/null; then packages+=' '"xorg"; fi
 target=$(lsblk -pilno partlabel,type,mountpoint | grep -G 'part /$' | head -n1 | cut -d "-" -f1 | cut -d"@" -f1)
 case $target in
   rk3288)
-    packages+=' '"linux-armv7-headers linux-api-headers xf86-video-armsoc-rockchip"
+    packages+=' '"linux-armv7-headers linux-api-headers"
     packages+=' '"mesa mesa-utils ffmpeg4.4-v4l2-request-git ffmpeg-v4l2-request-git"
     ;;
   rk3588)


### PR DESCRIPTION
This is a useless package as RK3288 devices have the Mesa Panfrost GPU driver working out of the box (which handles everything) and said driver does not use neither require 'xf86-video-armsoc-rockchip'

The only reason 'xf86-video-armsoc-rockchip' is even in the ALARM repos at all is because it was added during a time when people had to use Mali blobs for decent GPU acceleration, and the armsoc driver was needed in order to use it to get the Mali Fbdev/Xorg driver to work.